### PR TITLE
Improve application's observability

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "@stackframe/stack": "^2.8.108",
     "@t3-oss/env-nextjs": "^0.13.11",
     "@tanstack/react-virtual": "^3.14.2",
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "clsx": "^2.1.1",
     "dotenv": "^17.4.2",
     "kysely": "^0.29.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.14.2
         version: 3.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -2438,6 +2444,35 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
   '@vercel/functions@2.2.13':
     resolution: {integrity: sha512-14ArBSIIcOBx9nrEgaJb4Bw+en1gl6eSoJWh8qjifLl5G3E4dRXCFOT8HP+w66vb9Wqyd1lAQBrmRhRwOj9X9A==}
     engines: {node: '>= 18'}
@@ -2454,6 +2489,32 @@ packages:
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
@@ -6534,6 +6595,11 @@ snapshots:
       '@types/node': 25.9.3
     optional: true
 
+  '@vercel/analytics@2.0.1(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    optionalDependencies:
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+
   '@vercel/functions@2.2.13(@aws-sdk/credential-provider-web-identity@3.972.52)':
     dependencies:
       '@vercel/oidc': 2.0.2
@@ -6546,6 +6612,11 @@ snapshots:
       ms: 2.1.3
 
   '@vercel/oidc@3.2.0': {}
+
+  '@vercel/speed-insights@2.0.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    optionalDependencies:
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
 
   '@vitest/expect@4.1.8':
     dependencies:

--- a/src/actions/action-client.ts
+++ b/src/actions/action-client.ts
@@ -1,7 +1,25 @@
-import { createSafeActionClient } from "next-safe-action";
+import { createMiddleware, createSafeActionClient } from "next-safe-action";
 import { stackServerApp } from "@/auth/server";
+import { logger } from "@/lib/logger";
 
-export const actionClient = createSafeActionClient();
+const loggingMiddleware = createMiddleware().define(async ({ next }) => {
+  const start = Date.now();
+  logger.info("Server action started");
+
+  try {
+    const result = await next();
+    logger.info("Server action completed", { duration: Date.now() - start });
+    return result;
+  } catch (error) {
+    logger.error("Server action failed", {
+      duration: Date.now() - start,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+});
+
+export const actionClient = createSafeActionClient().use(loggingMiddleware);
 
 export const authActionClient = actionClient.use(async ({ next }) => {
   const user = await stackServerApp.getUser();

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Button } from "@heroui/react";
+import { useEffect } from "react";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-24 text-center">
+      <h2 className="text-2xl font-semibold">Something went wrong</h2>
+      <p className="text-foreground/60">
+        An unexpected error occurred. You can try again or come back later.
+      </p>
+      {error.digest && (
+        <p className="font-mono text-xs text-foreground/40">
+          Error ID: {error.digest}
+        </p>
+      )}
+      <Button onPress={reset}>Try again</Button>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,6 @@
 import "@/styles/globals.css";
+import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata } from "next";
 import { Montserrat } from "next/font/google";
 import { Providers } from "@/app/providers";
@@ -28,6 +30,8 @@ export default function RootLayout({
             {children}
           </main>
         </Providers>
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,8 +5,13 @@ export const config = createEnv({
   skipValidation: !!process.env.SKIP_ENV_VALIDATION,
   server: {
     DATABASE_URL: z.url(),
+    LOG_LEVEL: z
+      .enum(["debug", "info", "warn", "error"])
+      .optional()
+      .default(process.env.NODE_ENV === "production" ? "info" : "debug"),
   },
   runtimeEnv: {
     DATABASE_URL: process.env.DATABASE_URL,
+    LOG_LEVEL: process.env.LOG_LEVEL,
   },
 });

--- a/src/domain/services/recommendations.service.ts
+++ b/src/domain/services/recommendations.service.ts
@@ -4,6 +4,7 @@ import type { BionicleCharacter, BionicleSet, Wave } from "@/domain/sets";
 import { UserWishlistScale } from "@/domain/user-wishlist";
 import { RecommendationViewModel } from "@/domain/view-models/recommendation.view-model";
 import { SetViewModel } from "@/domain/view-models/set.view-model";
+import { logger } from "@/lib/logger";
 
 const NO_VARIATION_KEY = "__NO_VARIATION__";
 
@@ -56,6 +57,7 @@ type ScopeCounts = {
 } & CharacterScopeCounts &
   GenerationScopeCounts;
 
+// TODO: this could probably be improved using something like a strategy pattern
 export class RecommendationsService {
   constructor(
     private readonly setsRepository: SetsRepository,
@@ -94,7 +96,7 @@ export class RecommendationsService {
     );
     const scored = candidates.map((set) => this.scoreSet(set, scopeCounts));
 
-    return scored
+    const results = scored
       .toSorted((a, b) => {
         const byScore = b.score - a.score;
         if (byScore !== 0) {
@@ -116,6 +118,9 @@ export class RecommendationsService {
         return a.set.catalogNumber.localeCompare(b.set.catalogNumber);
       })
       .slice(0, limit);
+
+    logger.debug("Recommendations computed", { userId, count: results.length });
+    return results;
   }
 
   private buildScopeCounts(

--- a/src/domain/services/set-rating.service.ts
+++ b/src/domain/services/set-rating.service.ts
@@ -4,6 +4,7 @@ import { SetRatingEntity } from "@/domain/set-rating.entity";
 import type { SetViewModelContextLoader } from "@/domain/set-view-model.context-loader";
 import { SetViewModel } from "@/domain/view-models/set.view-model";
 import { SetsGroupedViewModel } from "@/domain/view-models/sets-grouped.view-model";
+import { logger } from "@/lib/logger";
 
 export class SetRatingService {
   constructor(
@@ -60,5 +61,6 @@ export class SetRatingService {
     await this.setRatingRepository.setRating(
       SetRatingEntity.create({ userId, setNumber, rating }),
     );
+    logger.info("Set rating saved", { userId, setNumber, rating });
   }
 }

--- a/src/domain/services/user-collection.service.ts
+++ b/src/domain/services/user-collection.service.ts
@@ -3,6 +3,7 @@ import type { UserCollectionRepositoryPort } from "@/data/repositories/user-coll
 import type { SetViewModelContextLoader } from "@/domain/set-view-model.context-loader";
 import { SetViewModel } from "@/domain/view-models/set.view-model";
 import { SetsGroupedViewModel } from "@/domain/view-models/sets-grouped.view-model";
+import { logger } from "@/lib/logger";
 
 export class UserCollectionService {
   constructor(
@@ -27,13 +28,13 @@ export class UserCollectionService {
     );
 
     if (isInCollection) {
-      return await this.collectionRepository.deleteFromCollection(
-        userId,
-        setNumber,
-      );
+      await this.collectionRepository.deleteFromCollection(userId, setNumber);
+      logger.info("Set removed from collection", { userId, setNumber });
+      return;
     }
 
     await this.collectionRepository.insert(userId, setNumber);
+    logger.info("Set added to collection", { userId, setNumber });
   }
 
   async getCollectionListViewModel(

--- a/src/domain/services/user-wishlist.service.ts
+++ b/src/domain/services/user-wishlist.service.ts
@@ -4,6 +4,7 @@ import type { SetViewModelContextLoader } from "@/domain/set-view-model.context-
 import type { UserWishlistScale } from "@/domain/user-wishlist";
 import { SetViewModel } from "@/domain/view-models/set.view-model";
 import { SetsGroupedViewModel } from "@/domain/view-models/sets-grouped.view-model";
+import { logger } from "@/lib/logger";
 
 export class UserWishlistService {
   constructor(
@@ -54,9 +55,11 @@ export class UserWishlistService {
 
     if (scale === null) {
       await this.wishlistRepository.deleteFromWishlist(userId, setNumber);
+      logger.info("Set removed from wishlist", { userId, setNumber });
       return;
     }
 
     await this.wishlistRepository.setWishlist(userId, setNumber, scale);
+    logger.info("Wishlist updated", { userId, setNumber, scale });
   }
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,88 @@
+import { headers } from "next/headers";
+import { cache } from "react";
+import { config } from "@/config";
+
+const getRequestId = cache(async (): Promise<string | undefined> => {
+  try {
+    const h = await headers();
+    return h.get("x-request-id") ?? undefined;
+  } catch {
+    return undefined;
+  }
+});
+
+type Level = "debug" | "info" | "warn" | "error";
+
+const LEVELS: Record<Level, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+function getMinLevel(): Level {
+  return config.LOG_LEVEL;
+}
+
+type LoggerInstance = {
+  debug: (message: string, data?: object) => void;
+  info: (message: string, data?: object) => void;
+  warn: (message: string, data?: object) => void;
+  error: (message: string, data?: object) => void;
+};
+
+function makeLogger(
+  resolveRequestId: () => Promise<string | undefined>,
+): LoggerInstance {
+  const emit = async (level: Level, message: string, data?: object) => {
+    if (LEVELS[level] < LEVELS[getMinLevel()]) {
+      return;
+    }
+
+    const requestId = await resolveRequestId();
+    const entry = {
+      data,
+      level,
+      message,
+      timestamp: new Date().toISOString(),
+      ...(requestId !== undefined ? { requestId } : {}),
+    };
+
+    if (level === "error") {
+      console.error(JSON.stringify(entry));
+    } else if (level === "warn") {
+      console.warn(JSON.stringify(entry));
+    } else if (level === "debug") {
+      console.debug(JSON.stringify(entry));
+    } else {
+      console.log(JSON.stringify(entry));
+    }
+  };
+
+  return {
+    debug: (message, data) => {
+      void emit("debug", message, data);
+    },
+    info: (message, data) => {
+      void emit("info", message, data);
+    },
+    warn: (message, data) => {
+      void emit("warn", message, data);
+    },
+    error: (message, data) => {
+      void emit("error", message, data);
+    },
+  };
+}
+
+/** Default logger — reads requestId from the current request's headers (RSC / Server Action context). */
+export const logger = makeLogger(getRequestId);
+
+/**
+ * Returns a logger instance bound to a known requestId.
+ * Use this in contexts where `headers()` from `next/headers` is unavailable,
+ * such as middleware (which reads headers directly from NextRequest).
+ */
+export function withRequestId(requestId: string): LoggerInstance {
+  return makeLogger(() => Promise.resolve(requestId));
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,30 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { withRequestId } from "@/lib/logger";
+
+export function proxy(request: NextRequest) {
+  const requestId = crypto.randomUUID();
+  const log = withRequestId(requestId);
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-request-id", requestId);
+
+  log.info("HTTP request", {
+    method: request.method,
+    path: request.nextUrl.pathname,
+  });
+
+  return NextResponse.next({ request: { headers: requestHeaders } });
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all paths except:
+     * - _next/static (static files)
+     * - _next/image (image optimisation)
+     * - Public image assets under /sets/
+     * - favicon.ico
+     */
+    "/((?!_next/static|_next/image|sets/|favicon.ico).*)",
+  ],
+};

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -10,5 +10,8 @@ export default defineProject({
     maxWorkers: 1,
     maxConcurrency: 1,
     globalSetup: ["./vitest.integration.global-setup.ts"],
+    env: {
+      SKIP_ENV_VALIDATION: "1",
+    },
   },
 });

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -7,5 +7,8 @@ export default defineProject({
     name: "unit",
     environment: "node",
     include: ["**/*.unit.test.ts"],
+    env: {
+      SKIP_ENV_VALIDATION: "1",
+    },
   },
 });


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add structured logging, request tracing, and Vercel analytics to the application
- Introduces a structured JSON logger in [`src/lib/logger.ts`](https://github.com/kacperbudny/biollector/pull/39/files#diff-73c4d73d75765ab186de329bbcb17bd1789967299b04fa88375c4a44a1797a27) with log-level filtering (configurable via `LOG_LEVEL` env var, defaulting to `debug` outside production and `info` in production) and optional request correlation via `x-request-id` header.
- Adds a Next.js middleware in [`src/proxy.ts`](https://github.com/kacperbudny/biollector/pull/39/files#diff-78bb005ca752086400a648d8aa3e60ce6f666e213da508caabd464d3bfeaf6a2) that generates a UUID per request, injects it as `x-request-id`, and logs each request's HTTP method and path.
- Attaches a logging middleware to the `next-safe-action` client so all server actions emit structured logs on start, success, and failure.
- Adds domain-level info/debug logs to key service methods: `toggleSet`, `setRating`, `setWishlist`, and `getRecommendations`.
- Adds an [`error.tsx`](https://github.com/kacperbudny/biollector/pull/39/files#diff-782fd804d3006001aeba1a91e51d6491b6d49dbaf5b7c3fee69aca89738c830b) route error boundary that logs errors to the browser console and provides a retry button.
- Renders `<Analytics />` and `<SpeedInsights />` from Vercel in the root layout to enable analytics and performance monitoring.
- Behavioral Change: `UserCollectionService.toggleSet` now returns `void` on removal instead of the repository's delete result.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd1fd6e.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->